### PR TITLE
Stop unnnecessary testing

### DIFF
--- a/src/boilerpipe_clj/extractors.clj
+++ b/src/boilerpipe_clj/extractors.clj
@@ -1,5 +1,5 @@
-(ns boilerpipe-clj.extractors 
-  (:import (de.l3s.boilerpipe.extractors 
+(ns boilerpipe-clj.extractors
+  (:import (de.l3s.boilerpipe.extractors
              ArticleExtractor
              ArticleSentencesExtractor
              DefaultExtractor)))

--- a/test/boilerpipe_clj/core_test.clj
+++ b/test/boilerpipe_clj/core_test.clj
@@ -3,7 +3,7 @@
             [boilerpipe-clj.core :refer :all]
             [boilerpipe-clj.extractors :as ext]))
 
-(defonce test-article 
+(defonce test-article
   (slurp "./test/boilerpipe_clj/resources/greenspun-test.html"))
 
 (def extractors [ext/default-extractor
@@ -13,8 +13,8 @@
 (deftest get-text-extraction
   (testing "get-text extracts something from an article
             without a provided extractor"
-    (let [res (get-text test-article)] 
-      (is (and 
+    (let [res (get-text test-article)]
+      (is (and
            (not= res "")
            (not= res nil)))))
   (testing "All the available extractors extract something

--- a/test/boilerpipe_clj/core_test.clj
+++ b/test/boilerpipe_clj/core_test.clj
@@ -10,7 +10,6 @@
                  ext/article-extractor
                  ext/article-sentence-extractor])
 
-;; TODO: Why does lein test say it tests 6400 assertions?
 (deftest get-text-extraction
   (testing "get-text extracts something from an article
             without a provided extractor"
@@ -21,6 +20,6 @@
   (testing "All the available extractors extract something
            from the article"
     (doseq [ext extractors
-            res (get-text test-article ext)]
+            :let [res (get-text test-article ext)]]
       (is (and (not= res "")
                (not (nil? res)))))))


### PR DESCRIPTION
The reason there were 6500 assertions is that the doseq had two collections to iterate over - the extractors, and each of the `res` strings (which were unnecessarily being iterated over).